### PR TITLE
fix: color_t values are now uint8_t

### DIFF
--- a/portal2-internal/sdk/misc/color_t.hpp
+++ b/portal2-internal/sdk/misc/color_t.hpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 
 struct color_t {
-    std::int32_t r = 0, g = 0, b = 0, a = 255;
+    std::uint8_t r = 0, g = 0, b = 0, a = 255;
 
     bool rainbow = false;
     float rainbow_value = 0.f;


### PR DESCRIPTION
which they probably should be, seeing as the values are always in 0-255 range.